### PR TITLE
missing images displaying and failed import removed

### DIFF
--- a/nodes/data/object/_properties.md
+++ b/nodes/data/object/_properties.md
@@ -1,5 +1,10 @@
-| Data                                                | Description                                                                                                                                                                                                                                                                                                                |
-| --------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| <span className="ndl-data">Properties To Set</span> | You can specify which properties to set by adding them to this list. Object don't have a schema with predefined properties like Records so you can choose any property name you want.                                                                                                                                      |
-| <span className="ndl-data">Property Types</span>    | Each property that you want to set will give you the option of setting the type of the value that you want to set to that property.                                                                                                                                                                                        |
-| <span className="ndl-data">Property Values</span>   | {/*##input:prop-\*##*/}The value to set on the Object property when the action is performed. (Signal is receieved on the **Do** input){/*##input##*/} Each property that you want to set (that was added to the **Properties to set** section above) will get it's own input both in the property panel and as a connection input. |
+<!-- It turns out that the @import of markdown files doesn't work in docsaurus.
+     so we have to duplicate the content into the create-new and set-object-prop README files 
+     This file is vestigal.  -->
+
+| Data | Description |
+| --- | --- |
+| <span className="ndl-data">Properties To Set</span> | You can specify which properties to set by adding them to this list. Object don't have a schema with predefined properties like Records so you can choose any property name you want. |
+
+| <span className="ndl-data">Property Types</span> | Each property that you want to set will give you the option of setting the type of the value that you want to set to that property. |
+| <span className="ndl-data">Property Values</span> | The value to set on the Object property when the action is performed. (Signal is receieved on the **Do** input) Each property that you want to set (that was added to the **Properties to set** section above) will get it's own input both in the property panel and as a connection input |

--- a/nodes/data/object/create-new-object/README.md
+++ b/nodes/data/object/create-new-object/README.md
@@ -13,7 +13,7 @@ The node can be used to create a fresh new [Object](/nodes/data/object/object-no
 <div className="ndl-image-with-background l">
 
 ![](/nodes/data/object/create-new-object/create-new-object.png)
-
+.
 </div>
 
 You can provide any number of properties with values for your new Object. When the **Done** signal is sent the Object is created and you can perform other actions using the Object.
@@ -22,7 +22,13 @@ You can provide any number of properties with values for your new Object. When t
 
 ## Inputs
 
-@include "../_properties.md"
+<!-- @include "../_properties.md" // Removed because docasaurus isn't configured for importing markdown files! -->
+
+| Data | Description |
+| --- | --- |
+| <span className="ndl-data">Properties To Set</span> | You can specify which properties to set by adding them to this list. Object don't have a schema with predefined properties like Records so you can choose any property name you want. |
+| <span className="ndl-data">Property Types</span> | Each property that you want to set will give you the option of setting the type of the value that you want to set to that property. |
+| <span className="ndl-data">Property Values</span> | The value to set on the Object property when the action is performed. (Signal is receieved on the **Do** input) Each property that you want to set (that was added to the **Properties to set** section above) will get it's own input both in the property panel and as a connection input |
 
 | Signal                                 | Description                                                                                                 |
 | -------------------------------------- | ----------------------------------------------------------------------------------------------------------- |

--- a/nodes/data/object/set-object-properties/README.md
+++ b/nodes/data/object/set-object-properties/README.md
@@ -21,7 +21,7 @@ You can then specify which properties you want to set on the Object in the prope
 <div className="ndl-image-with-background">
 
 ![](/nodes/data/object/set-object-properties/prop-panel.png)
-
+.
 </div>
 
 Finally, send a signal to **Do** to perform the action.
@@ -30,9 +30,15 @@ Finally, send a signal to **Do** to perform the action.
 
 ## Inputs
 
-@include "../_properties.md"
+<!-- @include "../_properties.md" // Removed because docasaurus isn't configured for importing markdown files! -->
 
-| Data                                        | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              |
+| Data | Description |
+| --- | --- |
+| <span className="ndl-data">Properties To Set</span> | You can specify which properties to set by adding them to this list. Object don't have a schema with predefined properties like Records so you can choose any property name you want. |
+| <span className="ndl-data">Property Types</span> | Each property that you want to set will give you the option of setting the type of the value that you want to set to that property. |
+| <span className="ndl-data">Property Values</span> | The value to set on the Object property when the action is performed. (Signal is receieved on the **Do** input) Each property that you want to set (that was added to the **Properties to set** section above) will get it's own input both in the property panel and as a connection input |
+
+| Data                                        | Description                                                                          |
 | ------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | <span className="ndl-data">Id Source</span> | An Id of a record is needed to perform the action of this node. The **Id Source** property specifies how this Id is retrieved, the options are:<br/><br/>`Specify explicitly`: This means you need to specify the Id of the record explicitly through e.g. a connection to the **Id** input.<br/>`From repeater`: This means that the Id for the record will be derived from a repeater. This option is only valid if the component this node is placed in is created by a repeater. Then this node will act on the repeater object that this component was created for. |
 | <span className="ndl-data">Id</span>        | {/*##input:id##*/}On this input you provide the **Id** of the object where you will set the properties.{/*##input##*/}                                                                                                                                                                                                                                                                                                                                                                                                                                                           |


### PR DESCRIPTION
## What kind of change does this PR introduce?

Concerns 2 pages: the set_object_properties and create_object pages.
Bug fix = removed the common @import, instead hard coded each of the input tables.
Bug fix = images did not display, but adding a period inside the DIV cause image to display. No idea why but it's a win.

## What is the current behavior?

No image and table is not displaying correctly on both pages:
https://noodlapp.github.io/noodl-docs/nodes/data/object/create-new-object/
https://noodlapp.github.io/noodl-docs/nodes/data/object/set-object-properties/
![image](https://github.com/user-attachments/assets/315d5cd8-34cc-4bff-88c5-2827ece2924f)

## What is the new behavior?
![image](https://github.com/user-attachments/assets/1106ca9e-03a9-49f4-bf87-0bc7592db1cf)

## Additional context
Not familiar enough with JSX actually, to debug why the images are not displaying unless there is at least one character inside the DIV with the image reference. Weird!  But folks can see the image now at least.

A little bit to help..